### PR TITLE
Repository meta info

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -13,4 +13,9 @@ class FeedsController < ApplicationController
   def repository_params
     { owner: params[:owner], repo: params[:repo] }
   end
+
+  def repository
+    @_repository ||= RepositoryPresenter.new(@repository)
+  end
+  helper_method :repository
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,10 +1,11 @@
 class Repository
   include ActiveModel::Model
-  attr_accessor :title,
-                :link,
+  attr_accessor :created_at,
                 :description,
-                :created_at,
-                :pull_requests
+                :link,
+                :owner,
+                :pull_requests,
+                :title
 
   def sorted_pull_requests
     @sorted ||= pull_requests.sort { |a, b| b.created_at <=> a.created_at }

--- a/app/presenters/repository_presenter.rb
+++ b/app/presenters/repository_presenter.rb
@@ -1,0 +1,24 @@
+require 'active_support/core_ext/module/delegation'
+
+class RepositoryPresenter
+  delegate :created_at,
+           :description,
+           :link,
+           :owner,
+           :pull_requests,
+           :sorted_pull_requests,
+           :title,
+           to: :@repository
+
+  def initialize(repository)
+    @repository = repository
+  end
+
+  def descriptive_title
+    "#{repository.owner}/#{repository.title} pull requests"
+  end
+
+  private
+
+  attr_reader :repository
+end

--- a/app/services/repository_serializer.rb
+++ b/app/services/repository_serializer.rb
@@ -20,8 +20,9 @@ class RepositorySerializer
       created_at: data.first['created_at'],
       description: base_attributes['description'],
       link: base_attributes['html_url'],
+      owner: base_attributes['owner']['login'],
       pull_requests: pull_requests,
-      title: "#{base_attributes['name']} pull requests"
+      title: base_attributes['name']
     }
   end
 

--- a/app/views/feeds/show.rss.builder
+++ b/app/views/feeds/show.rss.builder
@@ -1,11 +1,15 @@
 xml.instruct!
 xml.rss version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
   xml.channel do
-    xml.title "#{repository.descriptive_title} pull requests"
+    xml.title repository.descriptive_title
     xml.description repository.description
     xml.link repository.link
     xml.pubDate repository.created_at.rfc822
     xml.lastBuildDate repository.created_at.rfc822
+    xml.tag! 'atom:link',
+             href: feed_url(owner: repository.owner, repo: repository.title),
+             rel: 'self',
+             type: 'application/rss+xml'
 
     repository.sorted_pull_requests.each do |pr|
       xml.item do

--- a/app/views/feeds/show.rss.builder
+++ b/app/views/feeds/show.rss.builder
@@ -1,7 +1,7 @@
 xml.instruct!
 xml.rss version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
   xml.channel do
-    xml.title @repository.title
+    xml.title "#{@repository.title} pull requests"
     xml.description @repository.description
     xml.link @repository.link
     xml.pubDate @repository.created_at.rfc822

--- a/app/views/feeds/show.rss.builder
+++ b/app/views/feeds/show.rss.builder
@@ -1,13 +1,13 @@
 xml.instruct!
 xml.rss version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
   xml.channel do
-    xml.title "#{@repository.title} pull requests"
-    xml.description @repository.description
-    xml.link @repository.link
-    xml.pubDate @repository.created_at.rfc822
-    xml.lastBuildDate @repository.created_at.rfc822
+    xml.title "#{repository.descriptive_title} pull requests"
+    xml.description repository.description
+    xml.link repository.link
+    xml.pubDate repository.created_at.rfc822
+    xml.lastBuildDate repository.created_at.rfc822
 
-    @repository.sorted_pull_requests.each do |pr|
+    repository.sorted_pull_requests.each do |pr|
       xml.item do
         xml.title pr.title
         xml.description pr.description

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :pull_request do
     created_at { DateTime.current.to_s }
     description 'this fixed that one bug that has been annoying us for a while'
-    link 'http://github.com/foo/bar/pulls/1'
+    link 'http://github.com/github/code/pulls/1'
     title 'Fix that one bug'
   end
 end

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :repository do
     created_at { DateTime.current.to_s }
     description 'this old codebase'
-    link 'http://github.com/foo/bar'
+    link 'http://github.com/github/code'
     owner 'github'
     pull_requests { [build(:pull_request), build(:pull_request)] }
     title 'code'

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :repository do
     created_at { DateTime.current.to_s }
-    description 'this fixed that one bug that has been annoying us for a while'
-    link 'http://github.com/foo/bar/pulls/1'
-    title 'Fix that one bug'
+    description 'this old codebase'
+    link 'http://github.com/foo/bar'
+    owner 'github'
+    pull_requests { [build(:pull_request), build(:pull_request)] }
+    title 'code'
   end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -17,5 +17,4 @@ describe PullRequest do
       expect(pull_request.guid).to eq(pull_request.link)
     end
   end
-
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -17,4 +17,5 @@ describe PullRequest do
       expect(pull_request.guid).to eq(pull_request.link)
     end
   end
+
 end

--- a/spec/presenters/repository_presenter_spec.rb
+++ b/spec/presenters/repository_presenter_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe RepositoryPresenter do
+  describe '.def_delegators' do
+    it 'delegates methods to its repository' do
+      repository = build(:repository)
+      presenter = RepositoryPresenter.new(repository)
+
+      expect(presenter.created_at).to eq(repository.created_at)
+      expect(presenter.description).to eq(repository.description)
+      expect(presenter.link).to eq(repository.link)
+      expect(presenter.owner).to eq(repository.owner)
+      expect(presenter.pull_requests).to eq(repository.pull_requests)
+      expect(presenter.sorted_pull_requests).to eq(repository.sorted_pull_requests)
+      expect(presenter.title).to eq(repository.title)
+    end
+  end
+
+  describe '#descriptive_title' do
+    it 'returns the owner, title, and "pull requests"' do
+      repository = build(:repository, owner: 'github', title: 'code')
+      presenter = RepositoryPresenter.new(repository)
+
+      expect(presenter.descriptive_title).to eq('github/code pull requests')
+    end
+  end
+end

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -15,11 +15,16 @@ describe 'Repo requests' do
 
       get feed_path(owner: 'github', repo: 'code')
 
-      expect(xml[:title]).to eq('code pull requests')
+      expect(xml[:title]).to eq('github/code pull requests')
       expect(xml[:description]).to eq('A repo with some really good code.')
       expect(xml[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
       expect(xml[:lastBuildDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
       expect(xml[:link]).to eq('https://github.com/github/code')
+      expect(xml['atom:link']).to eq({
+        href: 'http://www.example.com/feeds/github/code',
+        rel: 'self',
+        type: 'application/rss+xml'
+      })
     end
 
     it 'has item attributes' do
@@ -46,7 +51,11 @@ describe 'Repo requests' do
   end
 
   def xml
-    @_xml ||= Hash.from_xml(response.body)['rss']['channel'].deep_symbolize_keys
+    @_xml ||= Hash.from_xml(response.body)['rss']['channel'].tap do |feed|
+      feed.deep_symbolize_keys!
+      feed['atom:link'] = feed[:link].last
+      feed[:link] = feed[:link].first
+    end
   end
 
   def first_item

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -30,38 +30,14 @@ describe 'Repo requests' do
       expect(first_item[:title]).to eq('Improve the code very much')
       expect(first_item[:description]).to eq('A very important pull request that makes the code much better.')
       expect(first_item[:link]).to eq('https://github.com/github/code/pull/564')
-      expect(first_item[:guid]).to eq('https://github.com/github/code/pull/564')
       expect(first_item[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
-    end
-
-    it 'has item attributes' do
-      stub_github_request
-
-      get feed_path(owner: 'foo', repo: 'bar')
-
-      expect(first_item[:title]).to be
-      expect(first_item[:description]).to be
-      expect(first_item[:link]).to be
-      expect(first_item[:pubDate]).to be
-      expect(first_item[:guid]).to be
-    end
-
-    it 'has item attributes' do
-      stub_github_request
-
-      get feed_path(owner: 'foo', repo: 'bar')
-
-      expect(first_item[:title]).to be
-      expect(first_item[:description]).to be
-      expect(first_item[:link]).to be
-      expect(first_item[:pubDate]).to be
-      expect(first_item[:guid]).to be
+      expect(first_item[:guid]).to eq('https://github.com/github/code/pull/564')
     end
 
     it 'formats the dates according to the rfc822 standard' do
       stub_github_request
 
-      get feed_path(owner: 'foo', repo: 'bar')
+      get feed_path(owner: 'github', repo: 'code')
 
       expect(xml[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
       expect(xml[:lastBuildDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -55,6 +55,18 @@ describe 'Repo requests' do
       expect(xml[:lastBuildDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
       expect(first_item[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
     end
+
+    it 'has item attributes' do
+      stub_github_request
+
+      get feed_path(owner: 'foo', repo: 'bar')
+
+      expect(first_item[:title]).to be
+      expect(first_item[:description]).to be
+      expect(first_item[:link]).to be
+      expect(first_item[:pubDate]).to be
+      expect(first_item[:guid]).to be
+    end
   end
 
   def xml

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -46,16 +46,6 @@ describe 'Repo requests' do
       expect(first_item[:guid]).to be
     end
 
-    it 'formats the dates according to the rfc822 standard' do
-      stub_github_request
-
-      get feed_path(owner: 'foo', repo: 'bar')
-
-      expect(xml[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
-      expect(xml[:lastBuildDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
-      expect(first_item[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
-    end
-
     it 'has item attributes' do
       stub_github_request
 
@@ -66,6 +56,16 @@ describe 'Repo requests' do
       expect(first_item[:link]).to be
       expect(first_item[:pubDate]).to be
       expect(first_item[:guid]).to be
+    end
+
+    it 'formats the dates according to the rfc822 standard' do
+      stub_github_request
+
+      get feed_path(owner: 'foo', repo: 'bar')
+
+      expect(xml[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
+      expect(xml[:lastBuildDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
+      expect(first_item[:pubDate]).to eq('Tue, 5 May 2015 07:50:40 +0000')
     end
   end
 

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -5,7 +5,7 @@ describe 'Repo requests' do
     it 'returns an rss response' do
       stub_github_request
 
-      get feed_path(owner: 'foo', repo: 'bar')
+      get feed_path(owner: 'github', repo: 'code')
 
       expect(response.content_type).to eq(Mime::Type.lookup_by_extension(:rss))
     end

--- a/spec/services/repository_serializer_spec.rb
+++ b/spec/services/repository_serializer_spec.rb
@@ -14,7 +14,8 @@ describe RepositorySerializer do
       expect(repository.created_at).to eq(Time.parse('2015-05-05T07:50:40Z'))
       expect(repository.description).to eq('A repo with some really good code.')
       expect(repository.link).to eq('https://github.com/github/code')
-      expect(repository.title).to eq('code pull requests')
+      expect(repository.owner).to eq('github')
+      expect(repository.title).to eq('code')
     end
 
     it 'serializes pull requests' do


### PR DESCRIPTION
This is mostly for non-pull request related info being added to the RSS feeds to help it comply with RSS standards. Things like:

* guid's
* rfc822 dates
* `rel="self"` link

I also created a repository presenter to separate the view from the model. Right now it just has a descriptive title, but it adds cleanliness to the view and controller.